### PR TITLE
symlink for hl3140cw and hl3150cdw now matches what CUPS requests

### DIFF
--- a/net-print/brother-genml1-bin/brother-genml1-bin-3.1.0-r1.ebuild
+++ b/net-print/brother-genml1-bin/brother-genml1-bin-3.1.0-r1.ebuild
@@ -66,7 +66,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	einfo "If you don't use avahi with nss-mdns you have to use a static IP addresss in your printer configuration"
-	einfo "If you want to use a broadcasted name add .local to it"
+	einfo "If you don't use avahi with nss-mdns, you'll have to use a static IP address in your printer configuration"
+	einfo "If you want to use a broadcasted name, add .local to it"
 	einfo "You can test if it's working with ping printername.local"
 }

--- a/net-print/brother-hl3140cw-bin/brother-hl3140cw-bin-1.1.4.ebuild
+++ b/net-print/brother-hl3140cw-bin/brother-hl3140cw-bin-1.1.4.ebuild
@@ -53,14 +53,14 @@ src_install() {
 	cp -r usr "${D}" || die
 
 	mkdir -p "${D}/usr/libexec/cups/filter" || die
-	( cd "${D}/usr/libexec/cups/filter/" && ln -s ../../../../opt/brother/Printers/hl3140cw/lpd/filterhl3140cw brlpdwrapperhl3140cw  ) || die
+	( cd "${D}/usr/libexec/cups/filter/" && ln -s ../../../../opt/brother/Printers/hl3140cw/lpd/filterhl3140cw brother_lpdwrapper_hl3140cw ) || die
 
 	mkdir -p "${D}/usr/share/cups/model" || die
 	( cd "${D}/usr/share/cups/model" && ln -s ../../../../opt/brother/Printers/hl3140cw/cupswrapper/brother_hl3140cw_printer_en.ppd ) || die
 }
 
 pkg_postinst() {
-	einfo "If you don't use avahi with nss-mdns you have to use a static IP addresss in your printer configuration"
-	einfo "If you want to use a broadcasted name add .local to it"
+	einfo "If you don't use avahi with nss-mdns, you'll have to use a static IP address in your printer configuration"
+	einfo "If you want to use a broadcasted name, add .local to it"
 	einfo "You can test if it's working with ping printername.local"
 }

--- a/net-print/brother-hl3150cdw-bin/brother-hl3150cdw-bin-1.1.4.ebuild
+++ b/net-print/brother-hl3150cdw-bin/brother-hl3150cdw-bin-1.1.4.ebuild
@@ -53,14 +53,14 @@ src_install() {
 	cp -r usr "${D}" || die
 
 	mkdir -p "${D}/usr/libexec/cups/filter" || die
-	( cd "${D}/usr/libexec/cups/filter/" && ln -s ../../../../opt/brother/Printers/hl3150cdw/lpd/filterhl3150cdw brlpdwrapperhl3150cdw  ) || die
+	( cd "${D}/usr/libexec/cups/filter/" && ln -s ../../../../opt/brother/Printers/hl3150cdw/lpd/filterhl3150cdw brother_lpdwrapper_hl3150cdw ) || die
 
 	mkdir -p "${D}/usr/share/cups/model" || die
 	( cd "${D}/usr/share/cups/model" && ln -s ../../../../opt/brother/Printers/hl3150cdw/cupswrapper/brother_hl3150cdw_printer_en.ppd ) || die
 }
 
 pkg_postinst() {
-	einfo "If you don't use avahi with nss-mdns you have to use a static IP addresss in your printer configuration"
-	einfo "If you want to use a broadcasted name add .local to it"
+	einfo "If you don't use avahi with nss-mdns, you'll have to use a static IP address in your printer configuration"
+	einfo "If you want to use a broadcasted name, add .local to it"
 	einfo "You can test if it's working with ping printername.local"
 }

--- a/net-print/brother-mfc7440n-bin/brother-mfc7440n-bin-3.1.0-r1.ebuild
+++ b/net-print/brother-mfc7440n-bin/brother-mfc7440n-bin-3.1.0-r1.ebuild
@@ -61,7 +61,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	einfo "If you don't use avahi with nss-mdns you have to use a static IP addresss in your printer confiugration"
-	einfo "If you want to use a broadcasted name add .local to it"
+	einfo "If you don't use avahi with nss-mdns, you'll have to use a static IP address in your printer confiugration"
+	einfo "If you want to use a broadcasted name, add .local to it"
 	einfo "You can test if it's working with ping printername.local"
 }


### PR DESCRIPTION
change in symlink to fix this message in CUPS:

Idle - "File "/usr/libexec/cups/filter/brother_lpdwrapper_hl3140cw" not available: No such file or directory"