### PR TITLE
brother dcp9055cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,8 @@ priority=9999
 
 Afterwards, simply run `emerge --sync`, and Portage should seamlessly make all our ebuilds available.
 
-## with layman
-
-Invoke the following:
-
-	layman -f -a brother-overlay
-	
-Or read the instructions on the [Gentoo Wiki](http://wiki.gentoo.org/wiki/Layman#Adding_custom_overlays).
-
 # Installation
 
 After performing those steps, the following should work (or any other package from this overlay):
 
-	sudo emerge -av media-gfx/brother-scan3-bin
+	sudo emerge -av net-print/brother-dcp9055cdn-bin

--- a/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r3.ebuild
+++ b/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r3.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit eutils rpm linux-info
+
+DESCRIPTION="Brother printer driver for DCP-9055CDN"
+
+HOMEPAGE="http://support.brother.com"
+
+SRC_URI="http://www.brother.com/pub/bsc/linux/dlf/dcp9055cdnlpr-1.1.1-5.i386.rpm
+	http://www.brother.com/pub/bsc/linux/dlf/dcp9055cdncupswrapper-1.1.1-5.i386.rpm"
+
+LICENSE="brother-eula GPL-2"
+
+SLOT="0"
+
+KEYWORDS="amd64 x86"
+
+RESTRICT="mirror strip"
+
+DEPEND="net-print/cups"
+RDEPEND="${DEPEND}"
+
+S=${WORKDIR}
+
+pkg_setup() {
+	CONFIG_CHECK=""
+	if use amd64; then
+		CONFIG_CHECK="${CONFIG_CHECK} ~IA32_EMULATION"
+	fi
+
+	linux-info_pkg_setup
+}
+
+src_unpack() {
+	rpm_unpack ${A}
+}
+
+src_install() {
+    MODEL="dcp9055cdn"
+    mkdir -p "${D}"usr/libexec/cups/filter || die
+    mkdir -p "${D}"usr/share/cups/model/Brother || die
+    cp -r usr "${D}" || die
+    ( ln -s "${D}"usr/local/Brother/Printer/${MODEL}/lpd/filterdcp9055cdn "${D}"usr/libexec/cups/filter/brlpdwrapperdcp9055cdn ) || die
+
+    ( ln -s "${D}"usr/local/Brother/Printer/${MODEL}/cupswrapper/${MODEL}.ppd "${D}"usr/share/cups/model/Brother/brother_${MODEL}_printer_en.ppd ) || die
+}

--- a/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r4.ebuild
+++ b/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r4.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+inherit eutils rpm linux-info
+
+DESCRIPTION="Brother printer driver for DCP-9055CDN"
+
+HOMEPAGE="http://support.brother.com"
+
+SRC_URI="http://www.brother.com/pub/bsc/linux/dlf/dcp9055cdnlpr-1.1.1-5.i386.rpm
+	http://www.brother.com/pub/bsc/linux/dlf/dcp9055cdncupswrapper-1.1.1-5.i386.rpm"
+
+LICENSE="brother-eula GPL-2"
+
+SLOT="0"
+
+KEYWORDS="amd64 x86"
+
+RESTRICT="mirror strip"
+
+DEPEND="net-print/cups"
+RDEPEND="${DEPEND}"
+
+S=${WORKDIR}
+
+pkg_setup() {
+	CONFIG_CHECK=""
+	if use amd64; then
+		CONFIG_CHECK="${CONFIG_CHECK} ~IA32_EMULATION"
+	fi
+
+	linux-info_pkg_setup
+}
+
+src_unpack() {
+	rpm_unpack ${A}
+}
+
+src_install() {
+	MODEL="dcp9055cdn"
+	mkdir -p "${D}"usr/libexec/cups/filter || die
+	mkdir -p "${D}"usr/share/cups/model/Brother || die
+	cp -r usr "${D}" || die
+
+	sed -n 94,232p "${D}usr/local/Brother/Printer/${MODEL}/cupswrapper/cupswrapper${MODEL}" | sed 's/${printer_model}/dcp9055cdn/g;s/${device_model}/Printer/g;s/${printer_name}/DCP9055CDN/g;s/\\//g' > "${D}usr"/libexec/cups/filter/brlpdwrapperdcp9055cdn || die
+	chmod 0755 "${D}"usr/libexec/cups/filter/brlpdwrapperdcp9055cdn || die
+
+	( ln -s "${D}"usr/local/Brother/Printer/${MODEL}/cupswrapper/${MODEL}.ppd "${D}"usr/share/cups/model/Brother/brother_${MODEL}_printer_en.ppd ) || die
+}


### PR DESCRIPTION
was in the mood to print something once in a while.
My dirty fix is added to brother-dcp9055cdn-bin-1.1.1-r3.ebuild, for completeness
Then I looked into it once again and there was typo in the original sed command it should be "Printer" instead of "Printers" now it works properly.
This path is as in dcp9055cdncupswrapper-1.1.1-5.i386.rpm. Rest of the sed was good. Now it is ok without the symlink.


I put this in brother-dcp9055cdn-bin-1.1.1-r4.ebuild. I think this version should be used.

The other files can be ignored, the commits are partly there because i am not yet very familier with github