### PR TITLE
net-print/brother-mfc7460dn-bin: Fix CUPS settings

### DIFF
--- a/net-print/brother-mfc7460dn-bin/brother-mfc7460dn-bin-2.0.4.ebuild
+++ b/net-print/brother-mfc7460dn-bin/brother-mfc7460dn-bin-2.0.4.ebuild
@@ -38,9 +38,14 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -f "${FILESDIR}/fix-path.sed" "${S}/lpd/filterMFC7460DN" || die
-	sed -f "${FILESDIR}/extract-cups-ppd.sed" "${S}/cupswrapper/cupswrapperMFC7460DN-2.0.4" > "${T}/brother-MFC7460DN.ppd" || die
-	sed -f "${FILESDIR}/extract-cups-filter.sed" -f "${FILESDIR}/fix-path.sed" "${S}/cupswrapper/cupswrapperMFC7460DN-2.0.4" > "${T}/brlpdwrapperMFC7460DN" || die
+	sed -i -f "${FILESDIR}/fix-paths.sed" "${S}/cupswrapper/cupswrapperMFC7460DN-${PV}" || die
+	sed -i -f "${FILESDIR}/fix-paths.sed" "${S}/inf/setupPrintcap2" || die
+	sed -i -f "${FILESDIR}/fix-paths.sed" "${S}/lpd/filterMFC7460DN" || die
+	sed -z -i -f "${FILESDIR}/fix-paths-in-binary.sed" "${S}/cupswrapper/brcupsconfig4" || die
+	sed -z -i -f "${FILESDIR}/fix-paths-in-binary.sed" "${S}/inf/braddprinter" || die
+	sed -z -i -f "${FILESDIR}/fix-paths-in-binary.sed" "${S}/inf/brprintconflsr3" || die
+	sed -f "${FILESDIR}/extract-cups-ppd.sed" "${S}/cupswrapper/cupswrapperMFC7460DN-${PV}" > "${T}/brother-MFC7460DN.ppd" || die
+	sed -f "${FILESDIR}/extract-cups-filter.sed" "${S}/cupswrapper/cupswrapperMFC7460DN-${PV}" > "${T}/brlpdwrapperMFC7460DN" || die
 }
 
 src_install() {

--- a/net-print/brother-mfc7460dn-bin/brother-mfc7460dn-bin-2.0.4.ebuild
+++ b/net-print/brother-mfc7460dn-bin/brother-mfc7460dn-bin-2.0.4.ebuild
@@ -47,6 +47,8 @@ src_install() {
 	keepdir /var/spool/lpd/MFC7460DN
 	dodir /opt/brother/Printers
 	cp -a "${S}" "${ED%/}/opt/brother/Printers" || die
+	fowners lp:lp /opt/brother/Printers/MFC7460DN/inf/brMFC7460DNrc
+	fperms 600 /opt/brother/Printers/MFC7460DN/inf/brMFC7460DNrc
 	insinto /opt/brother/Printers/MFC7460DN/cupswrapper
 	doins "${T}/brother-MFC7460DN.ppd"
 	exeinto /opt/brother/Printers/MFC7460DN/cupswrapper

--- a/net-print/brother-mfc7460dn-bin/files/fix-path.sed
+++ b/net-print/brother-mfc7460dn-bin/files/fix-path.sed
@@ -1,2 +1,0 @@
-#!/bin/sed -f
-s:/usr/local/Brother/Printer:/opt/brother/Printers:g

--- a/net-print/brother-mfc7460dn-bin/files/fix-paths-in-binary.sed
+++ b/net-print/brother-mfc7460dn-bin/files/fix-paths-in-binary.sed
@@ -1,0 +1,17 @@
+#!/bin/sed -zf
+:x
+\:/usr/local/Brother/Printer:{
+	s:/usr/local/Brother/Printer:/opt/brother/Printers:
+	s/$/\x00\x00\x00\x00\x00/
+	bx
+}
+\:/usr/local/Brother/inf:{
+	s:/usr/local/Brother/inf:/opt/brother/inf:
+	s/$/\x00\x00\x00\x00\x00\x00/
+	bx
+}
+\:/etc/printcap.local:{
+	s:\(/etc/printcap\).local:\1:
+	s/$/\x00\x00\x00\x00\x00\x00/
+	bx
+}

--- a/net-print/brother-mfc7460dn-bin/files/fix-paths.sed
+++ b/net-print/brother-mfc7460dn-bin/files/fix-paths.sed
@@ -1,0 +1,4 @@
+#!/bin/sed -f
+s:/usr/local/Brother/Printer:/opt/brother/Printers:g
+s:/usr/local/Brother/inf:/opt/brother/inf:g
+s:\(/etc/printcap\).local:\1:g


### PR DESCRIPTION
This fixes a few bugs in the ebuild I previously submitted. In particular, printing through the CUPS wrapper worked, but CUPS settings, e.g., for paper size, were not applied properly. This was due to two problems:
1. The file `/opt/brother/Printers/MFC7460DN/inf/brMFC7460DNrc` needs to be owned by `lp:lp` instead of `root:root`. I also set the mode to 0600 to match the behavior of the upstream install script.
2. The `/usr/local` paths need to be replaced in additional files, including the precompiled binaries. Luckily, this isn't a problem, since the `/opt` path is shorter, allowing strings to be padded at the end with null bytes.