### PR TITLE
net-print/brother-mfc-j985dw-bin: remove PaperType change from brmfcj985dwfunc

### DIFF
--- a/net-print/brother-mfc-j985dw-bin/brother-mfc-j985dw-bin-1.0.0-r1.ebuild
+++ b/net-print/brother-mfc-j985dw-bin/brother-mfc-j985dw-bin-1.0.0-r1.ebuild
@@ -28,14 +28,6 @@ QA_PRESTRIPPED="
 	/usr/bin/brprintconf_${model}
 "
 
-src_prepare() {
-	default
-	# Apparently this fixes a problem where letters print off-center
-	# https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=brother-mfc-j985dw
-	sed -i -e 's:^\(PaperType\)=.\+$:\1=Letter:g' \
-		opt/brother/Printers/${model}/inf/br${model}func || die
-}
-
 src_compile() {
 	emake -C "${wrapper_source}/brcupsconfig"
 }


### PR DESCRIPTION
It made A4 prints misaligned and was apparently added by mistake as I
can't see it applied in the AUR package either.

Package-Manager: Portage-2.3.38, Repoman-2.3.9