### PR TITLE
media-gfx/brother-scan4-bin: remove deprecated SYSFS key from udev rule

### DIFF
--- a/media-gfx/brother-scan4-bin/brother-scan4-bin-0.4.6-r1.ebuild
+++ b/media-gfx/brother-scan4-bin/brother-scan4-bin-0.4.6-r1.ebuild
@@ -29,6 +29,8 @@ RDEPEND="
 "
 DEPEND=""
 
+PATCHES=( "${FILESDIR}/${P}-fix-udev-rules.patch" )
+
 S="${WORKDIR}"
 
 src_install() {

--- a/media-gfx/brother-scan4-bin/files/brother-scan4-bin-0.4.6-fix-udev-rules.patch
+++ b/media-gfx/brother-scan4-bin/files/brother-scan4-bin-0.4.6-fix-udev-rules.patch
@@ -1,0 +1,12 @@
+diff --git a/opt/brother/scanner/udev-rules/type1/NN-brother-mfp-type1.rules b/opt/brother/scanner/udev-rules/type1/NN-brother-mfp-type1.rules
+index b0695be..4239d47 100644
+--- a/opt/brother/scanner/udev-rules/type1/NN-brother-mfp-type1.rules
++++ b/opt/brother/scanner/udev-rules/type1/NN-brother-mfp-type1.rules
+@@ -14,7 +14,6 @@ SUBSYSTEM!="usb_device", GOTO="brother_mfp_end"
+ LABEL="brother_mfp_udev_1"
+ 
+ 
+-SYSFS{idVendor}=="04f9", GOTO="brother_mfp_udev_2"
+ ATTRS{idVendor}=="04f9", GOTO="brother_mfp_udev_2"
+ GOTO="brother_mfp_end"
+ LABEL="brother_mfp_udev_2"


### PR DESCRIPTION
This fixes the following error: "unknown key 'SYSFS{idVendor}'
in /lib/udev/rules.d/41-brother-mfp-type1.rules:17"

The SYSFS key was removed from udev in 2011:
https://github.com/systemd/systemd/commit/289a1821a4a7636ce42a6c7adc3a9bb49421a5
after having been deprecated long before 2009:
https://github.com/systemd/systemd/commit/6d87ee2e0024074b77001e57ff1d7b7d24b1be

Package-Manager: Portage-2.3.53, Repoman-2.3.12
Signed-off-by: Louis Sautier <sbraz@gentoo.org>