### PR TITLE
Fixed a bug in HL-L3270CDW filter driver

### DIFF
--- a/net-print/brother-hll3270cdw-bin/brother-hll3270cdw-bin-1.0.2.ebuild
+++ b/net-print/brother-hll3270cdw-bin/brother-hll3270cdw-bin-1.0.2.ebuild
@@ -40,7 +40,7 @@ src_install() {
 
 	mkdir -p "${D}/usr/libexec/cups/filter" || die
 	( cd "${D}/usr/libexec/cups/filter/" && ln -s ../../../../opt/brother/Printers/hll3270cdw/lpd/filter_hll3270cdw brother_lpdwrapper_hll3270cdw ) || die
-	( cd "${D}/usr/libexec/cups/filter/" && sed 's/my $PRINTER = $0/my $PRINTER = Cwd::realpath ($0)/' ../../../../opt/brother/Printers/hll3270cdw/lpd/filter_hll3270cdw ) || die
+	( cd "${D}/usr/libexec/cups/filter/" && sed -i 's/my $PRINTER = $0/my $PRINTER = Cwd::realpath ($0)/' ../../../../opt/brother/Printers/hll3270cdw/lpd/filter_hll3270cdw ) || die
 	
 	mkdir -p "${D}/usr/share/cups/model" || die
 	( cd "${D}/usr/share/cups/model" && ln -s ../../../../opt/brother/Printers/hll3270cdw/cupswrapper/brother_hll3270cdw_printer_en.ppd ) || die

--- a/net-print/brother-hll3270cdw-bin/brother-hll3270cdw-bin-1.0.2.ebuild
+++ b/net-print/brother-hll3270cdw-bin/brother-hll3270cdw-bin-1.0.2.ebuild
@@ -40,7 +40,8 @@ src_install() {
 
 	mkdir -p "${D}/usr/libexec/cups/filter" || die
 	( cd "${D}/usr/libexec/cups/filter/" && ln -s ../../../../opt/brother/Printers/hll3270cdw/lpd/filter_hll3270cdw brother_lpdwrapper_hll3270cdw ) || die
-
+	( cd "${D}/usr/libexec/cups/filter/" && sed 's/my $PRINTER = $0/my $PRINTER = Cwd::realpath ($0)/' ../../../../opt/brother/Printers/hll3270cdw/lpd/filter_hll3270cdw ) || die
+	
 	mkdir -p "${D}/usr/share/cups/model" || die
 	( cd "${D}/usr/share/cups/model" && ln -s ../../../../opt/brother/Printers/hll3270cdw/cupswrapper/brother_hll3270cdw_printer_en.ppd ) || die
 }


### PR DESCRIPTION
I noticed I was unable to print unless the my $PRINTER = $0 is changed to my $PRINTER = Cwd::realpath ($0). I added a sed line to change this on the package and printing then functions properly.