### PR TITLE
remove all stale headers from ebuilds

### DIFF
--- a/media-gfx/brother-ads1000w-bin/brother-ads1000w-bin-1.0.ebuild
+++ b/media-gfx/brother-ads1000w-bin/brother-ads1000w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads1100w-bin/brother-ads1100w-bin-1.0.ebuild
+++ b/media-gfx/brother-ads1100w-bin/brother-ads1100w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads1500w-bin/brother-ads1500w-bin-1.0.ebuild
+++ b/media-gfx/brother-ads1500w-bin/brother-ads1500w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads1600w-bin/brother-ads1600w-bin-1.0.ebuild
+++ b/media-gfx/brother-ads1600w-bin/brother-ads1600w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads2000-bin/brother-ads2000-bin-1.0.ebuild
+++ b/media-gfx/brother-ads2000-bin/brother-ads2000-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads2100-bin/brother-ads2100-bin-1.0.ebuild
+++ b/media-gfx/brother-ads2100-bin/brother-ads2100-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads2400n-bin/brother-ads2400n-bin-1.0.ebuild
+++ b/media-gfx/brother-ads2400n-bin/brother-ads2400n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads2500w-bin/brother-ads2500w-bin-1.0.ebuild
+++ b/media-gfx/brother-ads2500w-bin/brother-ads2500w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads2600w-bin/brother-ads2600w-bin-1.0.ebuild
+++ b/media-gfx/brother-ads2600w-bin/brother-ads2600w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads2800w-bin/brother-ads2800w-bin-1.0.ebuild
+++ b/media-gfx/brother-ads2800w-bin/brother-ads2800w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads3000n-bin/brother-ads3000n-bin-1.0.ebuild
+++ b/media-gfx/brother-ads3000n-bin/brother-ads3000n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-ads3600w-bin/brother-ads3600w-bin-1.0.ebuild
+++ b/media-gfx/brother-ads3600w-bin/brother-ads3600w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp145c-bin/brother-dcp145c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp145c-bin/brother-dcp145c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp1510-bin/brother-dcp1510-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp1510-bin/brother-dcp1510-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp1600-bin/brother-dcp1600-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp1600-bin/brother-dcp1600-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp1608-bin/brother-dcp1608-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp1608-bin/brother-dcp1608-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp1610nw-bin/brother-dcp1610nw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp1610nw-bin/brother-dcp1610nw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp1610w-bin/brother-dcp1610w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp1610w-bin/brother-dcp1610w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp1618w-bin/brother-dcp1618w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp1618w-bin/brother-dcp1618w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp1619-bin/brother-dcp1619-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp1619-bin/brother-dcp1619-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp163c-bin/brother-dcp163c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp163c-bin/brother-dcp163c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp165c-bin/brother-dcp165c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp165c-bin/brother-dcp165c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp167c-bin/brother-dcp167c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp167c-bin/brother-dcp167c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp185c-bin/brother-dcp185c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp185c-bin/brother-dcp185c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp195c-bin/brother-dcp195c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp195c-bin/brother-dcp195c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp197c-bin/brother-dcp197c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp197c-bin/brother-dcp197c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp365cn-bin/brother-dcp365cn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp365cn-bin/brother-dcp365cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp373cw-bin/brother-dcp373cw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp373cw-bin/brother-dcp373cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp375cw-bin/brother-dcp375cw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp375cw-bin/brother-dcp375cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp377cw-bin/brother-dcp377cw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp377cw-bin/brother-dcp377cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp383c-bin/brother-dcp383c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp383c-bin/brother-dcp383c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp385c-bin/brother-dcp385c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp385c-bin/brother-dcp385c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp387c-bin/brother-dcp387c-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp387c-bin/brother-dcp387c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp390cn-bin/brother-dcp390cn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp390cn-bin/brother-dcp390cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp395cn-bin/brother-dcp395cn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp395cn-bin/brother-dcp395cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp535cn-bin/brother-dcp535cn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp535cn-bin/brother-dcp535cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp585cw-bin/brother-dcp585cw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp585cw-bin/brother-dcp585cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp595cn-bin/brother-dcp595cn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp595cn-bin/brother-dcp595cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp6690cw-bin/brother-dcp6690cw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp6690cw-bin/brother-dcp6690cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7030-bin/brother-dcp7030-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7030-bin/brother-dcp7030-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7040-bin/brother-dcp7040-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7040-bin/brother-dcp7040-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7045n-bin/brother-dcp7045n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7045n-bin/brother-dcp7045n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7055-bin/brother-dcp7055-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7055-bin/brother-dcp7055-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7055w-bin/brother-dcp7055w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7055w-bin/brother-dcp7055w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7057-bin/brother-dcp7057-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7057-bin/brother-dcp7057-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7057w-bin/brother-dcp7057w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7057w-bin/brother-dcp7057w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7060d-bin/brother-dcp7060d-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7060d-bin/brother-dcp7060d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7065dn-bin/brother-dcp7065dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7065dn-bin/brother-dcp7065dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7070dw-bin/brother-dcp7070dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7070dw-bin/brother-dcp7070dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7080-bin/brother-dcp7080-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7080-bin/brother-dcp7080-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7080d-bin/brother-dcp7080d-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7080d-bin/brother-dcp7080d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7180dn-bin/brother-dcp7180dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7180dn-bin/brother-dcp7180dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp7189dw-bin/brother-dcp7189dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp7189dw-bin/brother-dcp7189dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8070d-bin/brother-dcp8070d-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8070d-bin/brother-dcp8070d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8080dn-bin/brother-dcp8080dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8080dn-bin/brother-dcp8080dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8085dn-bin/brother-dcp8085dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8085dn-bin/brother-dcp8085dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8110d-bin/brother-dcp8110d-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8110d-bin/brother-dcp8110d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8110dn-bin/brother-dcp8110dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8110dn-bin/brother-dcp8110dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8112dn-bin/brother-dcp8112dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8112dn-bin/brother-dcp8112dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8150dn-bin/brother-dcp8150dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8150dn-bin/brother-dcp8150dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8152dn-bin/brother-dcp8152dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8152dn-bin/brother-dcp8152dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8155dn-bin/brother-dcp8155dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8155dn-bin/brother-dcp8155dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8157dn-bin/brother-dcp8157dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8157dn-bin/brother-dcp8157dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp8250dn-bin/brother-dcp8250dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp8250dn-bin/brother-dcp8250dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9010cn-bin/brother-dcp9010cn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9010cn-bin/brother-dcp9010cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9015cdw-bin/brother-dcp9015cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9015cdw-bin/brother-dcp9015cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9017cdw-bin/brother-dcp9017cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9017cdw-bin/brother-dcp9017cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9020cdn-bin/brother-dcp9020cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9020cdn-bin/brother-dcp9020cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9020cdw-bin/brother-dcp9020cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9020cdw-bin/brother-dcp9020cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9022cdw-bin/brother-dcp9022cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9022cdw-bin/brother-dcp9022cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9040cn-bin/brother-dcp9040cn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9040cn-bin/brother-dcp9040cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9042cdn-bin/brother-dcp9042cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9042cdn-bin/brother-dcp9042cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9045cdn-bin/brother-dcp9045cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9045cdn-bin/brother-dcp9045cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcp9270cdn-bin/brother-dcp9270cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcp9270cdn-bin/brother-dcp9270cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj100-bin/brother-dcpj100-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj100-bin/brother-dcpj100-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj105-bin/brother-dcpj105-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj105-bin/brother-dcpj105-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj125-bin/brother-dcpj125-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj125-bin/brother-dcpj125-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj132n-bin/brother-dcpj132n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj132n-bin/brother-dcpj132n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj132w-bin/brother-dcpj132w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj132w-bin/brother-dcpj132w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj137n-bin/brother-dcpj137n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj137n-bin/brother-dcpj137n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj140w-bin/brother-dcpj140w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj140w-bin/brother-dcpj140w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj152n-bin/brother-dcpj152n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj152n-bin/brother-dcpj152n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj152w-bin/brother-dcpj152w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj152w-bin/brother-dcpj152w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj172w-bin/brother-dcpj172w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj172w-bin/brother-dcpj172w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj315w-bin/brother-dcpj315w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj315w-bin/brother-dcpj315w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj4110dw-bin/brother-dcpj4110dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj4110dw-bin/brother-dcpj4110dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj4120dw-bin/brother-dcpj4120dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj4120dw-bin/brother-dcpj4120dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj4210n-bin/brother-dcpj4210n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj4210n-bin/brother-dcpj4210n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj4215n-bin/brother-dcpj4215n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj4215n-bin/brother-dcpj4215n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj4220n-bin/brother-dcpj4220n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj4220n-bin/brother-dcpj4220n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj4225n-bin/brother-dcpj4225n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj4225n-bin/brother-dcpj4225n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj515n-bin/brother-dcpj515n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj515n-bin/brother-dcpj515n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj515w-bin/brother-dcpj515w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj515w-bin/brother-dcpj515w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj525n-bin/brother-dcpj525n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj525n-bin/brother-dcpj525n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj525w-bin/brother-dcpj525w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj525w-bin/brother-dcpj525w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj540n-bin/brother-dcpj540n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj540n-bin/brother-dcpj540n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj552dw-bin/brother-dcpj552dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj552dw-bin/brother-dcpj552dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj552n-bin/brother-dcpj552n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj552n-bin/brother-dcpj552n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj557n-bin/brother-dcpj557n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj557n-bin/brother-dcpj557n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj562dw-bin/brother-dcpj562dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj562dw-bin/brother-dcpj562dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj562n-bin/brother-dcpj562n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj562n-bin/brother-dcpj562n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj715n-bin/brother-dcpj715n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj715n-bin/brother-dcpj715n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj715w-bin/brother-dcpj715w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj715w-bin/brother-dcpj715w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj725dw-bin/brother-dcpj725dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj725dw-bin/brother-dcpj725dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj725n-bin/brother-dcpj725n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj725n-bin/brother-dcpj725n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj740n-bin/brother-dcpj740n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj740n-bin/brother-dcpj740n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj752dw-bin/brother-dcpj752dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj752dw-bin/brother-dcpj752dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj752n-bin/brother-dcpj752n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj752n-bin/brother-dcpj752n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj757n-bin/brother-dcpj757n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj757n-bin/brother-dcpj757n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj762n-bin/brother-dcpj762n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj762n-bin/brother-dcpj762n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj785dw-bin/brother-dcpj785dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj785dw-bin/brother-dcpj785dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj925dw-bin/brother-dcpj925dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj925dw-bin/brother-dcpj925dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj925n-bin/brother-dcpj925n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj925n-bin/brother-dcpj925n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj940n-bin/brother-dcpj940n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj940n-bin/brother-dcpj940n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj952n-bin/brother-dcpj952n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj952n-bin/brother-dcpj952n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj957n-bin/brother-dcpj957n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj957n-bin/brother-dcpj957n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj962n-bin/brother-dcpj962n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj962n-bin/brother-dcpj962n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj963n-bin/brother-dcpj963n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj963n-bin/brother-dcpj963n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpj983n-bin/brother-dcpj983n-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpj983n-bin/brother-dcpj983n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl2500d-bin/brother-dcpl2500d-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl2500d-bin/brother-dcpl2500d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl2520d-bin/brother-dcpl2520d-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl2520d-bin/brother-dcpl2520d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl2520dw-bin/brother-dcpl2520dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl2520dw-bin/brother-dcpl2520dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl2540dn-bin/brother-dcpl2540dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl2540dn-bin/brother-dcpl2540dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl2540dw-bin/brother-dcpl2540dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl2540dw-bin/brother-dcpl2540dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl2560dw-bin/brother-dcpl2560dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl2560dw-bin/brother-dcpl2560dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl5500d-bin/brother-dcpl5500d-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl5500d-bin/brother-dcpl5500d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl5500dn-bin/brother-dcpl5500dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl5500dn-bin/brother-dcpl5500dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl5502dn-bin/brother-dcpl5502dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl5502dn-bin/brother-dcpl5502dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl5600dn-bin/brother-dcpl5600dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl5600dn-bin/brother-dcpl5600dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl5602dn-bin/brother-dcpl5602dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl5602dn-bin/brother-dcpl5602dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl5650dn-bin/brother-dcpl5650dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl5650dn-bin/brother-dcpl5650dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl5652dn-bin/brother-dcpl5652dn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl5652dn-bin/brother-dcpl5652dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl6600dw-bin/brother-dcpl6600dw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl6600dw-bin/brother-dcpl6600dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl8400cdn-bin/brother-dcpl8400cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl8400cdn-bin/brother-dcpl8400cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpl8450cdw-bin/brother-dcpl8450cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpl8450cdw-bin/brother-dcpl8450cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpt300-bin/brother-dcpt300-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpt300-bin/brother-dcpt300-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpt500w-bin/brother-dcpt500w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpt500w-bin/brother-dcpt500w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-dcpt700w-bin/brother-dcpt700w-bin-1.0.ebuild
+++ b/media-gfx/brother-dcpt700w-bin/brother-dcpt700w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-fax2940-bin/brother-fax2940-bin-1.0.ebuild
+++ b/media-gfx/brother-fax2940-bin/brother-fax2940-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-fax2950-bin/brother-fax2950-bin-1.0.ebuild
+++ b/media-gfx/brother-fax2950-bin/brother-fax2950-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-fax2990-bin/brother-fax2990-bin-1.0.ebuild
+++ b/media-gfx/brother-fax2990-bin/brother-fax2990-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-fax7860dw-bin/brother-fax7860dw-bin-1.0.ebuild
+++ b/media-gfx/brother-fax7860dw-bin/brother-fax7860dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-faxl2700dn-bin/brother-faxl2700dn-bin-1.0.ebuild
+++ b/media-gfx/brother-faxl2700dn-bin/brother-faxl2700dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-hl2280dw-bin/brother-hl2280dw-bin-1.0.ebuild
+++ b/media-gfx/brother-hl2280dw-bin/brother-hl2280dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-hl3180cdw-bin/brother-hl3180cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-hl3180cdw-bin/brother-hl3180cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-hll2380dw-bin/brother-hll2380dw-bin-1.0.ebuild
+++ b/media-gfx/brother-hll2380dw-bin/brother-hll2380dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc1810-bin/brother-mfc1810-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc1810-bin/brother-mfc1810-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc1900-bin/brother-mfc1900-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc1900-bin/brother-mfc1900-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc1906-bin/brother-mfc1906-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc1906-bin/brother-mfc1906-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc1908-bin/brother-mfc1908-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc1908-bin/brother-mfc1908-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc1910nw-bin/brother-mfc1910nw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc1910nw-bin/brother-mfc1910nw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc1910w-bin/brother-mfc1910w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc1910w-bin/brother-mfc1910w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc1919nw-bin/brother-mfc1919nw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc1919nw-bin/brother-mfc1919nw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc250c-bin/brother-mfc250c-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc250c-bin/brother-mfc250c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc253cw-bin/brother-mfc253cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc253cw-bin/brother-mfc253cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc255cw-bin/brother-mfc255cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc255cw-bin/brother-mfc255cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc257cw-bin/brother-mfc257cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc257cw-bin/brother-mfc257cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc290c-bin/brother-mfc290c-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc290c-bin/brother-mfc290c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc295cn-bin/brother-mfc295cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc295cn-bin/brother-mfc295cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc297c-bin/brother-mfc297c-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc297c-bin/brother-mfc297c-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc490cn-bin/brother-mfc490cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc490cn-bin/brother-mfc490cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc490cw-bin/brother-mfc490cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc490cw-bin/brother-mfc490cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc495cn-bin/brother-mfc495cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc495cn-bin/brother-mfc495cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc495cw-bin/brother-mfc495cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc495cw-bin/brother-mfc495cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc5490cn-bin/brother-mfc5490cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc5490cn-bin/brother-mfc5490cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc5890cn-bin/brother-mfc5890cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc5890cn-bin/brother-mfc5890cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc5895cw-bin/brother-mfc5895cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc5895cw-bin/brother-mfc5895cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc6490cn-bin/brother-mfc6490cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc6490cn-bin/brother-mfc6490cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc6490cw-bin/brother-mfc6490cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc6490cw-bin/brother-mfc6490cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc670cd-bin/brother-mfc670cd-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc670cd-bin/brother-mfc670cd-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc675cd-bin/brother-mfc675cd-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc675cd-bin/brother-mfc675cd-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc6890cdw-bin/brother-mfc6890cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc6890cdw-bin/brother-mfc6890cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc6890cn-bin/brother-mfc6890cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc6890cn-bin/brother-mfc6890cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc695cdn-bin/brother-mfc695cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc695cdn-bin/brother-mfc695cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7240-bin/brother-mfc7240-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7240-bin/brother-mfc7240-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7290-bin/brother-mfc7290-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7290-bin/brother-mfc7290-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7320-bin/brother-mfc7320-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7320-bin/brother-mfc7320-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7340-bin/brother-mfc7340-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7340-bin/brother-mfc7340-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc735cd-bin/brother-mfc735cd-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc735cd-bin/brother-mfc735cd-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7360-bin/brother-mfc7360-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7360-bin/brother-mfc7360-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7360n-bin/brother-mfc7360n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7360n-bin/brother-mfc7360n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7362n-bin/brother-mfc7362n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7362n-bin/brother-mfc7362n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7365dn-bin/brother-mfc7365dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7365dn-bin/brother-mfc7365dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7380-bin/brother-mfc7380-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7380-bin/brother-mfc7380-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7440n-bin/brother-mfc7440n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7440n-bin/brother-mfc7440n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7450-bin/brother-mfc7450-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7450-bin/brother-mfc7450-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7460dn-bin/brother-mfc7460dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7460dn-bin/brother-mfc7460dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7470d-bin/brother-mfc7470d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7470d-bin/brother-mfc7470d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7480d-bin/brother-mfc7480d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7480d-bin/brother-mfc7480d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7840n-bin/brother-mfc7840n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7840n-bin/brother-mfc7840n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7840w-bin/brother-mfc7840w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7840w-bin/brother-mfc7840w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7860dn-bin/brother-mfc7860dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7860dn-bin/brother-mfc7860dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7860dw-bin/brother-mfc7860dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7860dw-bin/brother-mfc7860dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7880dn-bin/brother-mfc7880dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7880dn-bin/brother-mfc7880dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc7889dw-bin/brother-mfc7889dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc7889dw-bin/brother-mfc7889dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc790cw-bin/brother-mfc790cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc790cw-bin/brother-mfc790cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc795cw-bin/brother-mfc795cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc795cw-bin/brother-mfc795cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8370dn-bin/brother-mfc8370dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8370dn-bin/brother-mfc8370dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8380dn-bin/brother-mfc8380dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8380dn-bin/brother-mfc8380dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8480dn-bin/brother-mfc8480dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8480dn-bin/brother-mfc8480dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8510dn-bin/brother-mfc8510dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8510dn-bin/brother-mfc8510dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8512dn-bin/brother-mfc8512dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8512dn-bin/brother-mfc8512dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8515dn-bin/brother-mfc8515dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8515dn-bin/brother-mfc8515dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8520dn-bin/brother-mfc8520dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8520dn-bin/brother-mfc8520dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8530dn-bin/brother-mfc8530dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8530dn-bin/brother-mfc8530dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8535dn-bin/brother-mfc8535dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8535dn-bin/brother-mfc8535dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8540dn-bin/brother-mfc8540dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8540dn-bin/brother-mfc8540dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8680dn-bin/brother-mfc8680dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8680dn-bin/brother-mfc8680dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8690dw-bin/brother-mfc8690dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8690dw-bin/brother-mfc8690dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8710dw-bin/brother-mfc8710dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8710dw-bin/brother-mfc8710dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8712dw-bin/brother-mfc8712dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8712dw-bin/brother-mfc8712dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8810dw-bin/brother-mfc8810dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8810dw-bin/brother-mfc8810dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8880dn-bin/brother-mfc8880dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8880dn-bin/brother-mfc8880dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8890dw-bin/brother-mfc8890dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8890dw-bin/brother-mfc8890dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8910dw-bin/brother-mfc8910dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8910dw-bin/brother-mfc8910dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8912dw-bin/brother-mfc8912dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8912dw-bin/brother-mfc8912dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8950dw-bin/brother-mfc8950dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8950dw-bin/brother-mfc8950dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc8952dw-bin/brother-mfc8952dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc8952dw-bin/brother-mfc8952dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9010cn-bin/brother-mfc9010cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9010cn-bin/brother-mfc9010cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9120cn-bin/brother-mfc9120cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9120cn-bin/brother-mfc9120cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9125cn-bin/brother-mfc9125cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9125cn-bin/brother-mfc9125cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9130cw-bin/brother-mfc9130cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9130cw-bin/brother-mfc9130cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9140cdn-bin/brother-mfc9140cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9140cdn-bin/brother-mfc9140cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9142cdn-bin/brother-mfc9142cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9142cdn-bin/brother-mfc9142cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc930cdn-bin/brother-mfc930cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc930cdn-bin/brother-mfc930cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9320cw-bin/brother-mfc9320cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9320cw-bin/brother-mfc9320cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9325cw-bin/brother-mfc9325cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9325cw-bin/brother-mfc9325cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9330cdw-bin/brother-mfc9330cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9330cdw-bin/brother-mfc9330cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9332cdw-bin/brother-mfc9332cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9332cdw-bin/brother-mfc9332cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9335cdw-bin/brother-mfc9335cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9335cdw-bin/brother-mfc9335cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9340cdw-bin/brother-mfc9340cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9340cdw-bin/brother-mfc9340cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9342cdw-bin/brother-mfc9342cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9342cdw-bin/brother-mfc9342cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc935cdn-bin/brother-mfc935cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc935cdn-bin/brother-mfc935cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9440cn-bin/brother-mfc9440cn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9440cn-bin/brother-mfc9440cn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9450cdn-bin/brother-mfc9450cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9450cdn-bin/brother-mfc9450cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9460cdn-bin/brother-mfc9460cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9460cdn-bin/brother-mfc9460cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9465cdn-bin/brother-mfc9465cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9465cdn-bin/brother-mfc9465cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9560cdw-bin/brother-mfc9560cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9560cdw-bin/brother-mfc9560cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9640cw-bin/brother-mfc9640cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9640cw-bin/brother-mfc9640cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9840cdw-bin/brother-mfc9840cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9840cdw-bin/brother-mfc9840cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc990cw-bin/brother-mfc990cw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc990cw-bin/brother-mfc990cw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfc9970cdw-bin/brother-mfc9970cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfc9970cdw-bin/brother-mfc9970cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj200-bin/brother-mfcj200-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj200-bin/brother-mfcj200-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj220-bin/brother-mfcj220-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj220-bin/brother-mfcj220-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj2310-bin/brother-mfcj2310-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj2310-bin/brother-mfcj2310-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj2320-bin/brother-mfcj2320-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj2320-bin/brother-mfcj2320-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj245-bin/brother-mfcj245-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj245-bin/brother-mfcj245-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj2510-bin/brother-mfcj2510-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj2510-bin/brother-mfcj2510-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj265w-bin/brother-mfcj265w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj265w-bin/brother-mfcj265w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj270w-bin/brother-mfcj270w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj270w-bin/brother-mfcj270w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj2720-bin/brother-mfcj2720-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj2720-bin/brother-mfcj2720-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj280w-bin/brother-mfcj280w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj280w-bin/brother-mfcj280w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj285dw-bin/brother-mfcj285dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj285dw-bin/brother-mfcj285dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj3520-bin/brother-mfcj3520-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj3520-bin/brother-mfcj3520-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj3720-bin/brother-mfcj3720-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj3720-bin/brother-mfcj3720-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj410-bin/brother-mfcj410-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj410-bin/brother-mfcj410-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj410w-bin/brother-mfcj410w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj410w-bin/brother-mfcj410w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj415w-bin/brother-mfcj415w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj415w-bin/brother-mfcj415w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj425w-bin/brother-mfcj425w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj425w-bin/brother-mfcj425w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj430w-bin/brother-mfcj430w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj430w-bin/brother-mfcj430w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4310dw-bin/brother-mfcj4310dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4310dw-bin/brother-mfcj4310dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4320dw-bin/brother-mfcj4320dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4320dw-bin/brother-mfcj4320dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj432w-bin/brother-mfcj432w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj432w-bin/brother-mfcj432w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj435w-bin/brother-mfcj435w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj435w-bin/brother-mfcj435w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4410dw-bin/brother-mfcj4410dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4410dw-bin/brother-mfcj4410dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4420dw-bin/brother-mfcj4420dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4420dw-bin/brother-mfcj4420dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj450dw-bin/brother-mfcj450dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj450dw-bin/brother-mfcj450dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4510dw-bin/brother-mfcj4510dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4510dw-bin/brother-mfcj4510dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4510n-bin/brother-mfcj4510n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4510n-bin/brother-mfcj4510n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4520dw-bin/brother-mfcj4520dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4520dw-bin/brother-mfcj4520dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj460dw-bin/brother-mfcj460dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj460dw-bin/brother-mfcj460dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4610dw-bin/brother-mfcj4610dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4610dw-bin/brother-mfcj4610dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4620dw-bin/brother-mfcj4620dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4620dw-bin/brother-mfcj4620dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4625dw-bin/brother-mfcj4625dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4625dw-bin/brother-mfcj4625dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj470dw-bin/brother-mfcj470dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj470dw-bin/brother-mfcj470dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4710dw-bin/brother-mfcj4710dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4710dw-bin/brother-mfcj4710dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4720n-bin/brother-mfcj4720n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4720n-bin/brother-mfcj4720n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4725n-bin/brother-mfcj4725n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4725n-bin/brother-mfcj4725n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj475dw-bin/brother-mfcj475dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj475dw-bin/brother-mfcj475dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj480dw-bin/brother-mfcj480dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj480dw-bin/brother-mfcj480dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4810dn-bin/brother-mfcj4810dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4810dn-bin/brother-mfcj4810dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj485dw-bin/brother-mfcj485dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj485dw-bin/brother-mfcj485dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj4910cdw-bin/brother-mfcj4910cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj4910cdw-bin/brother-mfcj4910cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5320dw-bin/brother-mfcj5320dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5320dw-bin/brother-mfcj5320dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5520dw-bin/brother-mfcj5520dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5520dw-bin/brother-mfcj5520dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5620cdw-bin/brother-mfcj5620cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5620cdw-bin/brother-mfcj5620cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5620dw-bin/brother-mfcj5620dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5620dw-bin/brother-mfcj5620dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5625dw-bin/brother-mfcj5625dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5625dw-bin/brother-mfcj5625dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5720cdw-bin/brother-mfcj5720cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5720cdw-bin/brother-mfcj5720cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5720dw-bin/brother-mfcj5720dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5720dw-bin/brother-mfcj5720dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5820dn-bin/brother-mfcj5820dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5820dn-bin/brother-mfcj5820dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5910cdw-bin/brother-mfcj5910cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5910cdw-bin/brother-mfcj5910cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5910dw-bin/brother-mfcj5910dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5910dw-bin/brother-mfcj5910dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj5920dw-bin/brother-mfcj5920dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj5920dw-bin/brother-mfcj5920dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj615n-bin/brother-mfcj615n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj615n-bin/brother-mfcj615n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj615w-bin/brother-mfcj615w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj615w-bin/brother-mfcj615w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj625dw-bin/brother-mfcj625dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj625dw-bin/brother-mfcj625dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj630w-bin/brother-mfcj630w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj630w-bin/brother-mfcj630w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj650dw-bin/brother-mfcj650dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj650dw-bin/brother-mfcj650dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6510dw-bin/brother-mfcj6510dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6510dw-bin/brother-mfcj6510dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6520dw-bin/brother-mfcj6520dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6520dw-bin/brother-mfcj6520dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6570cdw-bin/brother-mfcj6570cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6570cdw-bin/brother-mfcj6570cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6573cdw-bin/brother-mfcj6573cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6573cdw-bin/brother-mfcj6573cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6710cdw-bin/brother-mfcj6710cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6710cdw-bin/brother-mfcj6710cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6710dw-bin/brother-mfcj6710dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6710dw-bin/brother-mfcj6710dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6720dw-bin/brother-mfcj6720dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6720dw-bin/brother-mfcj6720dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6770cdw-bin/brother-mfcj6770cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6770cdw-bin/brother-mfcj6770cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj680dw-bin/brother-mfcj680dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj680dw-bin/brother-mfcj680dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6910cdw-bin/brother-mfcj6910cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6910cdw-bin/brother-mfcj6910cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6910dw-bin/brother-mfcj6910dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6910dw-bin/brother-mfcj6910dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6920dw-bin/brother-mfcj6920dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6920dw-bin/brother-mfcj6920dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6925dw-bin/brother-mfcj6925dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6925dw-bin/brother-mfcj6925dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6970cdw-bin/brother-mfcj6970cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6970cdw-bin/brother-mfcj6970cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6973cdw-bin/brother-mfcj6973cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6973cdw-bin/brother-mfcj6973cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6975cdw-bin/brother-mfcj6975cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6975cdw-bin/brother-mfcj6975cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj6990cdw-bin/brother-mfcj6990cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj6990cdw-bin/brother-mfcj6990cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj700d-bin/brother-mfcj700d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj700d-bin/brother-mfcj700d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj705d-bin/brother-mfcj705d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj705d-bin/brother-mfcj705d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj710d-bin/brother-mfcj710d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj710d-bin/brother-mfcj710d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj720d-bin/brother-mfcj720d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj720d-bin/brother-mfcj720d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj727d-bin/brother-mfcj727d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj727d-bin/brother-mfcj727d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj730dn-bin/brother-mfcj730dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj730dn-bin/brother-mfcj730dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj800d-bin/brother-mfcj800d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj800d-bin/brother-mfcj800d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj805d-bin/brother-mfcj805d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj805d-bin/brother-mfcj805d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj810dn-bin/brother-mfcj810dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj810dn-bin/brother-mfcj810dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj820dn-bin/brother-mfcj820dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj820dn-bin/brother-mfcj820dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj825dw-bin/brother-mfcj825dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj825dw-bin/brother-mfcj825dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj825n-bin/brother-mfcj825n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj825n-bin/brother-mfcj825n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj827dn-bin/brother-mfcj827dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj827dn-bin/brother-mfcj827dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj830dn-bin/brother-mfcj830dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj830dn-bin/brother-mfcj830dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj835dw-bin/brother-mfcj835dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj835dw-bin/brother-mfcj835dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj840n-bin/brother-mfcj840n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj840n-bin/brother-mfcj840n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj850dn-bin/brother-mfcj850dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj850dn-bin/brother-mfcj850dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj855dn-bin/brother-mfcj855dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj855dn-bin/brother-mfcj855dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj860dn-bin/brother-mfcj860dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj860dn-bin/brother-mfcj860dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj870dw-bin/brother-mfcj870dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj870dw-bin/brother-mfcj870dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj870n-bin/brother-mfcj870n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj870n-bin/brother-mfcj870n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj875dw-bin/brother-mfcj875dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj875dw-bin/brother-mfcj875dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj877n-bin/brother-mfcj877n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj877n-bin/brother-mfcj877n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj880dw-bin/brother-mfcj880dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj880dw-bin/brother-mfcj880dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj880n-bin/brother-mfcj880n-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj880n-bin/brother-mfcj880n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj885dw-bin/brother-mfcj885dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj885dw-bin/brother-mfcj885dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj890dn-bin/brother-mfcj890dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj890dn-bin/brother-mfcj890dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj897dn-bin/brother-mfcj897dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj897dn-bin/brother-mfcj897dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj900dn-bin/brother-mfcj900dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj900dn-bin/brother-mfcj900dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj950dn-bin/brother-mfcj950dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj950dn-bin/brother-mfcj950dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj955dn-bin/brother-mfcj955dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj955dn-bin/brother-mfcj955dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj960dn-bin/brother-mfcj960dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj960dn-bin/brother-mfcj960dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj980dn-bin/brother-mfcj980dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj980dn-bin/brother-mfcj980dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj985dw-bin/brother-mfcj985dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj985dw-bin/brother-mfcj985dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj987dn-bin/brother-mfcj987dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj987dn-bin/brother-mfcj987dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcj990dn-bin/brother-mfcj990dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcj990dn-bin/brother-mfcj990dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl2680w-bin/brother-mfcl2680w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl2680w-bin/brother-mfcl2680w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl2700d-bin/brother-mfcl2700d-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl2700d-bin/brother-mfcl2700d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl2700dn-bin/brother-mfcl2700dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl2700dn-bin/brother-mfcl2700dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl2700dw-bin/brother-mfcl2700dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl2700dw-bin/brother-mfcl2700dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl2705dw-bin/brother-mfcl2705dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl2705dw-bin/brother-mfcl2705dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl2720dn-bin/brother-mfcl2720dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl2720dn-bin/brother-mfcl2720dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl2720dw-bin/brother-mfcl2720dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl2720dw-bin/brother-mfcl2720dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl2740dw-bin/brother-mfcl2740dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl2740dw-bin/brother-mfcl2740dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl3730cdn-bin/brother-mfcl3730cdn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl3730cdn-bin/brother-mfcl3730cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5700dn-bin/brother-mfcl5700dn-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5700dn-bin/brother-mfcl5700dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5700dw-bin/brother-mfcl5700dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5700dw-bin/brother-mfcl5700dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5702dw-bin/brother-mfcl5702dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5702dw-bin/brother-mfcl5702dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5750dw-bin/brother-mfcl5750dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5750dw-bin/brother-mfcl5750dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5755dw-bin/brother-mfcl5755dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5755dw-bin/brother-mfcl5755dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5800dw-bin/brother-mfcl5800dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5800dw-bin/brother-mfcl5800dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5802dw-bin/brother-mfcl5802dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5802dw-bin/brother-mfcl5802dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5850dw-bin/brother-mfcl5850dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5850dw-bin/brother-mfcl5850dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5900dw-bin/brother-mfcl5900dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5900dw-bin/brother-mfcl5900dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl5902dw-bin/brother-mfcl5902dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl5902dw-bin/brother-mfcl5902dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl6700dw-bin/brother-mfcl6700dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl6700dw-bin/brother-mfcl6700dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl6702dw-bin/brother-mfcl6702dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl6702dw-bin/brother-mfcl6702dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl6750dw-bin/brother-mfcl6750dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl6750dw-bin/brother-mfcl6750dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl6800dw-bin/brother-mfcl6800dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl6800dw-bin/brother-mfcl6800dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl6900dw-bin/brother-mfcl6900dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl6900dw-bin/brother-mfcl6900dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl6902dw-bin/brother-mfcl6902dw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl6902dw-bin/brother-mfcl6902dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl8600cdw-bin/brother-mfcl8600cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl8600cdw-bin/brother-mfcl8600cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl8650cdw-bin/brother-mfcl8650cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl8650cdw-bin/brother-mfcl8650cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl8850cdw-bin/brother-mfcl8850cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl8850cdw-bin/brother-mfcl8850cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfcl9550cdw-bin/brother-mfcl9550cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl9550cdw-bin/brother-mfcl9550cdw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-mfct800w-bin/brother-mfct800w-bin-1.0.ebuild
+++ b/media-gfx/brother-mfct800w-bin/brother-mfct800w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/media-gfx/brother-scan3-bin/brother-scan3-bin-0.2.13.1.ebuild
+++ b/media-gfx/brother-scan3-bin/brother-scan3-bin-0.2.13.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/net-print/brother-dcp1510-bin/brother-dcp1510-bin-3.0.1-r1.ebuild
+++ b/net-print/brother-dcp1510-bin/brother-dcp1510-bin-3.0.1-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/net-print/brother-dcp1610w-bin/brother-dcp1610w-bin-3.0.1.ebuild
+++ b/net-print/brother-dcp1610w-bin/brother-dcp1610w-bin-3.0.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/net-print/brother-dcp7055-bin/brother-dcp7055-bin-1.0.ebuild
+++ b/net-print/brother-dcp7055-bin/brother-dcp7055-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp7055w-bin/brother-dcp7055w-bin-1.0.ebuild
+++ b/net-print/brother-dcp7055w-bin/brother-dcp7055w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp7060d-bin/brother-dcp7060d-bin-1.0.ebuild
+++ b/net-print/brother-dcp7060d-bin/brother-dcp7060d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp7065dn-bin/brother-dcp7065dn-bin-1.0.ebuild
+++ b/net-print/brother-dcp7065dn-bin/brother-dcp7065dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp7070dw-bin/brother-dcp7070dw-bin-1.0.ebuild
+++ b/net-print/brother-dcp7070dw-bin/brother-dcp7070dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp8070d-bin/brother-dcp8070d-bin-1.0.ebuild
+++ b/net-print/brother-dcp8070d-bin/brother-dcp8070d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp8085dn-bin/brother-dcp8085dn-bin-1.0.ebuild
+++ b/net-print/brother-dcp8085dn-bin/brother-dcp8085dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp8110dn-bin/brother-dcp8110dn-bin-1.0.ebuild
+++ b/net-print/brother-dcp8110dn-bin/brother-dcp8110dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp8250dn-bin/brother-dcp8250dn-bin-1.0.ebuild
+++ b/net-print/brother-dcp8250dn-bin/brother-dcp8250dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcp9020cdw-bin/brother-dcp9020cdw-bin-1.1.2-r1.ebuild
+++ b/net-print/brother-dcp9020cdw-bin/brother-dcp9020cdw-bin-1.1.2-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-dcp9022cdw-bin/brother-dcp9022cdw-bin-1.1.3.ebuild
+++ b/net-print/brother-dcp9022cdw-bin/brother-dcp9022cdw-bin-1.1.3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-dcp9040cn-bin/brother-dcp9040cn-bin-1.0.3.1.ebuild
+++ b/net-print/brother-dcp9040cn-bin/brother-dcp9040cn-bin-1.0.3.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r1.ebuild
+++ b/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r2.ebuild
+++ b/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r3.ebuild
+++ b/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r3.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r4.ebuild
+++ b/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1-r4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1.ebuild
+++ b/net-print/brother-dcp9055cdn-bin/brother-dcp9055cdn-bin-1.1.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-dcpl2500d-bin/brother-dcpl2500d-bin-1.0.ebuild
+++ b/net-print/brother-dcpl2500d-bin/brother-dcpl2500d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcpl2520dw-bin/brother-dcpl2520dw-bin-1.0.ebuild
+++ b/net-print/brother-dcpl2520dw-bin/brother-dcpl2520dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcpl2540dn-bin/brother-dcpl2540dn-bin-1.0.ebuild
+++ b/net-print/brother-dcpl2540dn-bin/brother-dcpl2540dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-dcpl2560dw-bin/brother-dcpl2560dw-bin-1.0.ebuild
+++ b/net-print/brother-dcpl2560dw-bin/brother-dcpl2560dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-genml1-bin/brother-genml1-bin-3.1.0-r1.ebuild
+++ b/net-print/brother-genml1-bin/brother-genml1-bin-3.1.0-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl1110-bin/brother-hl1110-bin-3.0.1-r1.ebuild
+++ b/net-print/brother-hl1110-bin/brother-hl1110-bin-3.0.1-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl2130-bin/brother-hl2130-bin-1.0.ebuild
+++ b/net-print/brother-hl2130-bin/brother-hl2130-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl2135w-bin/brother-hl2135w-bin-1.0.ebuild
+++ b/net-print/brother-hl2135w-bin/brother-hl2135w-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl2240-bin/brother-hl2240-bin-1.0.ebuild
+++ b/net-print/brother-hl2240-bin/brother-hl2240-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl2240d-bin/brother-hl2240d-bin-1.0.ebuild
+++ b/net-print/brother-hl2240d-bin/brother-hl2240d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl2250dn-bin/brother-hl2250dn-bin-1.0.ebuild
+++ b/net-print/brother-hl2250dn-bin/brother-hl2250dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl2270dw-bin/brother-hl2270dw-bin-1.0.ebuild
+++ b/net-print/brother-hl2270dw-bin/brother-hl2270dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl3070cw-bin/brother-hl3070cw-bin-1.1.2.ebuild
+++ b/net-print/brother-hl3070cw-bin/brother-hl3070cw-bin-1.1.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-hl3140cw-bin/brother-hl3140cw-bin-1.1.4.ebuild
+++ b/net-print/brother-hl3140cw-bin/brother-hl3140cw-bin-1.1.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl3150cdw-bin/brother-hl3150cdw-bin-1.1.4.ebuild
+++ b/net-print/brother-hl3150cdw-bin/brother-hl3150cdw-bin-1.1.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl4150cdn-bin/brother-hl4150cdn-bin-1.1.1.ebuild
+++ b/net-print/brother-hl4150cdn-bin/brother-hl4150cdn-bin-1.1.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-hl4570cdw-bin/brother-hl4570cdw-bin-1.1.1.ebuild
+++ b/net-print/brother-hl4570cdw-bin/brother-hl4570cdw-bin-1.1.1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-hl5340d-bin/brother-hl5340d-bin-1.0.ebuild
+++ b/net-print/brother-hl5340d-bin/brother-hl5340d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl5350dn-bin/brother-hl5350dn-bin-1.0.ebuild
+++ b/net-print/brother-hl5350dn-bin/brother-hl5350dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl5350dnlt-bin/brother-hl5350dnlt-bin-1.0.ebuild
+++ b/net-print/brother-hl5350dnlt-bin/brother-hl5350dnlt-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl5370dw-bin/brother-hl5370dw-bin-1.0.ebuild
+++ b/net-print/brother-hl5370dw-bin/brother-hl5370dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl5380dn-bin/brother-hl5380dn-bin-1.0.ebuild
+++ b/net-print/brother-hl5380dn-bin/brother-hl5380dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl5440d-bin/brother-hl5440d-bin-1.0.ebuild
+++ b/net-print/brother-hl5440d-bin/brother-hl5440d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl5450dn-bin/brother-hl5450dn-bin-1.0.ebuild
+++ b/net-print/brother-hl5450dn-bin/brother-hl5450dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl5450dnt-bin/brother-hl5450dnt-bin-1.0.ebuild
+++ b/net-print/brother-hl5450dnt-bin/brother-hl5450dnt-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl5470dw-bin/brother-hl5470dw-bin-1.0.ebuild
+++ b/net-print/brother-hl5470dw-bin/brother-hl5470dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl6180dw-bin/brother-hl6180dw-bin-1.0.ebuild
+++ b/net-print/brother-hl6180dw-bin/brother-hl6180dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hl6180dwt-bin/brother-hl6180dwt-bin-1.0.ebuild
+++ b/net-print/brother-hl6180dwt-bin/brother-hl6180dwt-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hll2300d-bin/brother-hll2300d-bin-1.0.ebuild
+++ b/net-print/brother-hll2300d-bin/brother-hll2300d-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hll2340dw-bin/brother-hll2340dw-bin-1.0.ebuild
+++ b/net-print/brother-hll2340dw-bin/brother-hll2340dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hll2360dn-bin/brother-hll2360dn-bin-1.0.ebuild
+++ b/net-print/brother-hll2360dn-bin/brother-hll2360dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hll2365dw-bin/brother-hll2365dw-bin-1.0.ebuild
+++ b/net-print/brother-hll2365dw-bin/brother-hll2365dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-hll8350cdw-bin/brother-hll8350cdw-bin-1.1.2-r1.ebuild
+++ b/net-print/brother-hll8350cdw-bin/brother-hll8350cdw-bin-1.1.2-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-mfc7360n-bin/brother-mfc7360n-bin-1.0.ebuild
+++ b/net-print/brother-mfc7360n-bin/brother-mfc7360n-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc7440n-bin/brother-mfc7440n-bin-3.1.0-r1.ebuild
+++ b/net-print/brother-mfc7440n-bin/brother-mfc7440n-bin-3.1.0-r1.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-mfc7460dn-bin/brother-mfc7460dn-bin-1.0.ebuild
+++ b/net-print/brother-mfc7460dn-bin/brother-mfc7460dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc7860dw-bin/brother-mfc7860dw-bin-1.0.ebuild
+++ b/net-print/brother-mfc7860dw-bin/brother-mfc7860dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc8370dn-bin/brother-mfc8370dn-bin-1.0.ebuild
+++ b/net-print/brother-mfc8370dn-bin/brother-mfc8370dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc8380dn-bin/brother-mfc8380dn-bin-1.0.ebuild
+++ b/net-print/brother-mfc8380dn-bin/brother-mfc8380dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc8510dn-bin/brother-mfc8510dn-bin-1.0.ebuild
+++ b/net-print/brother-mfc8510dn-bin/brother-mfc8510dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc8520dn-bin/brother-mfc8520dn-bin-1.0.ebuild
+++ b/net-print/brother-mfc8520dn-bin/brother-mfc8520dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc8880dn-bin/brother-mfc8880dn-bin-1.0.ebuild
+++ b/net-print/brother-mfc8880dn-bin/brother-mfc8880dn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc8890dw-bin/brother-mfc8890dw-bin-1.0.ebuild
+++ b/net-print/brother-mfc8890dw-bin/brother-mfc8890dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc8950dw-bin/brother-mfc8950dw-bin-1.0.ebuild
+++ b/net-print/brother-mfc8950dw-bin/brother-mfc8950dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc8950dwt-bin/brother-mfc8950dwt-bin-1.0.ebuild
+++ b/net-print/brother-mfc8950dwt-bin/brother-mfc8950dwt-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfc9130cw-bin/brother-mfc9130cw-bin-1.1.2.ebuild
+++ b/net-print/brother-mfc9130cw-bin/brother-mfc9130cw-bin-1.1.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-mfc9140cdn-bin/brother-mfc9140cdn-bin-1.0.ebuild
+++ b/net-print/brother-mfc9140cdn-bin/brother-mfc9140cdn-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=6
 

--- a/net-print/brother-mfc9320cw-bin/brother-mfc9320cw-bin-1.1.2.ebuild
+++ b/net-print/brother-mfc9320cw-bin/brother-mfc9320cw-bin-1.1.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-mfc9330cdw-bin/brother-mfc9330cdw-bin-1.1.2.ebuild
+++ b/net-print/brother-mfc9330cdw-bin/brother-mfc9330cdw-bin-1.1.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-mfc9332cdw-bin/brother-mfc9332cdw-bin-1.1.4.ebuild
+++ b/net-print/brother-mfc9332cdw-bin/brother-mfc9332cdw-bin-1.1.4.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-mfc9340cdw-bin/brother-mfc9340cdw-bin-1.1.2.ebuild
+++ b/net-print/brother-mfc9340cdw-bin/brother-mfc9340cdw-bin-1.1.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI=5
 

--- a/net-print/brother-mfcj485dw-bin/brother-mfcj485dw-bin-1.0.0.ebuild
+++ b/net-print/brother-mfcj485dw-bin/brother-mfcj485dw-bin-1.0.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# \$Id\$
 
 API="7"
 inherit rpm

--- a/net-print/brother-mfcj880dw-bin/brother-mfcj880dw-bin-1.0.0-r0.ebuild
+++ b/net-print/brother-mfcj880dw-bin/brother-mfcj880dw-bin-1.0.0-r0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 # Original made for Brother MFC-J880DW printer by Chris Morgenstern[machredsch]
 

--- a/net-print/brother-mfcl2700dw-bin/brother-mfcl2700dw-bin-1.0.ebuild
+++ b/net-print/brother-mfcl2700dw-bin/brother-mfcl2700dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfcl2720dw-bin/brother-mfcl2720dw-bin-1.0.ebuild
+++ b/net-print/brother-mfcl2720dw-bin/brother-mfcl2720dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfcl2740dw-bin/brother-mfcl2740dw-bin-1.0.ebuild
+++ b/net-print/brother-mfcl2740dw-bin/brother-mfcl2740dw-bin-1.0.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="6"
 

--- a/net-print/brother-mfcl3770cdw-bin/brother-mfcl3770cdw-bin-1.0.2.ebuild
+++ b/net-print/brother-mfcl3770cdw-bin/brother-mfcl3770cdw-bin-1.0.2.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# \$Id\$
 
 API="7"
 inherit rpm


### PR DESCRIPTION
Trying to fix [Travis errors about ebuild.badheader](https://github.com/stefan-langenmaier/brother-overlay/pull/75#issuecomment-546165076) following a [suggestion](https://github.com/stefan-langenmaier/brother-overlay/pull/75#discussion_r338223318) from @stefan-langenmaier.