### PR TITLE
convert leading spaces into tabs and fix empty lines in ebuilds

### DIFF
--- a/net-print/brother-hl3070cw-bin/brother-hl3070cw-bin-1.1.2.ebuild
+++ b/net-print/brother-hl3070cw-bin/brother-hl3070cw-bin-1.1.2.ebuild
@@ -29,15 +29,15 @@ RDEPEND="${DEPEND}"
 S=${WORKDIR}
 
 pkg_setup() {
-    CONFIG_CHECK=""
-    if use amd64; then
+	CONFIG_CHECK=""
+	if use amd64; then
 	CONFIG_CHECK="${CONFIG_CHECK} ~IA32_EMULATION"
-	if ! has_multilib_profile; then
-	    die "This package CANNOT be installed on pure 64-bit system. You need multilib enabled."
+		if ! has_multilib_profile; then
+			die "This package CANNOT be installed on pure 64-bit system. You need multilib enabled."
+		fi
 	fi
-    fi
 
-    linux-info_pkg_setup
+	linux-info_pkg_setup
 }
 
 src_unpack() {
@@ -60,9 +60,9 @@ src_install() {
 }
 
 pkg_postinst() {
-    chmod 755 /opt/brother/Printers/hl3070cw/lpd
-    chmod 755 /opt/brother/Printers/hl3070cw/inf
-    chmod 755 /opt/brother/Printers/hl3070cw
-    chmod 755 /opt/brother/Printers
-    chmod 755 /opt/brother
+	chmod 755 /opt/brother/Printers/hl3070cw/lpd
+	chmod 755 /opt/brother/Printers/hl3070cw/inf
+	chmod 755 /opt/brother/Printers/hl3070cw
+	chmod 755 /opt/brother/Printers
+	chmod 755 /opt/brother
 }

--- a/net-print/brother-hll3270cdw-bin/brother-hll3270cdw-bin-1.0.2.ebuild
+++ b/net-print/brother-hll3270cdw-bin/brother-hll3270cdw-bin-1.0.2.ebuild
@@ -41,7 +41,7 @@ src_install() {
 	mkdir -p "${D}/usr/libexec/cups/filter" || die
 	( cd "${D}/usr/libexec/cups/filter/" && ln -s ../../../../opt/brother/Printers/hll3270cdw/lpd/filter_hll3270cdw brother_lpdwrapper_hll3270cdw ) || die
 	( cd "${D}/usr/libexec/cups/filter/" && sed -i 's/my $PRINTER = $0/my $PRINTER = Cwd::realpath ($0)/' ../../../../opt/brother/Printers/hll3270cdw/lpd/filter_hll3270cdw ) || die
-	
+
 	mkdir -p "${D}/usr/share/cups/model" || die
 	( cd "${D}/usr/share/cups/model" && ln -s ../../../../opt/brother/Printers/hll3270cdw/cupswrapper/brother_hll3270cdw_printer_en.ppd ) || die
 }


### PR DESCRIPTION
Fixes Travis `ebuild.minorsyn`: _Ebuild contains leading spaces_, _Trailing whitespace error_.