### PR TITLE
fix an inconsistent use of tabs and spaces in metadata.xml indentation

### DIFF
--- a/media-gfx/brother-scan2-bin/metadata.xml
+++ b/media-gfx/brother-scan2-bin/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <longdescription>Brother scanner tool version 2</longdescription>
-  <use>
-	<flag name="usb">Enable this, if you want to scan over usb connection.</flag>
-  </use>
+	<longdescription>Brother scanner tool version 2</longdescription>
+	<use>
+		<flag name="usb">Enable this, if you want to scan over usb connection.</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
Fixes just ` media-gfx/brother-scan2-bin/metadata.xml`.