### PR TITLE
fix inherit deprecated: drop versionator and bump to EAPI 7

### DIFF
--- a/media-gfx/brother-scan3-bin/brother-scan3-bin-0.2.13_p1.ebuild
+++ b/media-gfx/brother-scan3-bin/brother-scan3-bin-0.2.13_p1.ebuild
@@ -1,14 +1,16 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 #based on ebuilds from the funtoo and flow overlay
 
-inherit rpm versionator
+inherit rpm
 
-MY_PV="$(replace_version_separator 3 -)"
-MY_PN=brscan3
+MY_PN="${PN/brother-/br}"
+MY_PN="${MY_PN/-bin/}"
+MY_PV="${PV/-${PR}/}"
+MY_PV="${MY_PV/_p/-}"
 
 DESCRIPTION="Brother scanner driver (brscan3)"
 

--- a/net-print/brother-dcp9040cn-bin/brother-dcp9040cn-bin-1.0.3_p1.ebuild
+++ b/net-print/brother-dcp9040cn-bin/brother-dcp9040cn-bin-1.0.3_p1.ebuild
@@ -1,13 +1,14 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit eutils versionator rpm linux-info
+inherit eutils rpm linux-info
 
-MY_VERSION=$(replace_version_separator 3 '-')
-MY_PRINTER=${PN#*-}
-MY_PRINTER=${MY_PRINTER%-*}
+MY_PRINTER="${PN/brother-/}"
+MY_PRINTER="${MY_PRINTER/-bin/}"
+MY_VERSION="${PV/-${PR}/}"
+MY_VERSION="${MY_VERSION/_p/-}"
 PRINTER_NAME=${MY_PRINTER^^}
 
 DESCRIPTION="Brother printer driver for ${PRINTER_NAME}"
@@ -44,6 +45,7 @@ src_unpack() {
 }
 
 src_prepare() {
+	default
 	perl -i -pe 'BEGIN{$stop=0} $stop = !$stop if /ENDOFWFILTER/; if(!$stop) {s/\$1/\$2/g;s!/usr!\$1/usr!;s!/etc!\$1/etc!}' \
 	  "usr/local/Brother/Printer/${MY_PRINTER}/cupswrapper/cupswrapperSetup_${MY_PRINTER}"
 }


### PR DESCRIPTION
The fixed ebuilds are bumped to EAPI 7: there's no need to inherit `eapi7-ver`, replacement of `versionator`, since it is bundled in EAPI 7.

By now, **custom** **MY_*** **variables** make no use of _eapi7-ver functions_.