### PR TITLE
fix ebuilds copyright ownership: from 'Gentoo Foundation' to 'Gentoo Authors'

### DIFF
--- a/media-gfx/brother-mfcl8690cdw-bin/brother-mfcl8690cdw-bin-1.0.ebuild
+++ b/media-gfx/brother-mfcl8690cdw-bin/brother-mfcl8690cdw-bin-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"

--- a/net-print/brother-hll3270cdw-bin/brother-hll3270cdw-bin-1.0.2.ebuild
+++ b/net-print/brother-hll3270cdw-bin/brother-hll3270cdw-bin-1.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5

--- a/net-print/brother-mfc6490cw-bin/brother-mfc6490cw-bin-1.1.2_p2.ebuild
+++ b/net-print/brother-mfc6490cw-bin/brother-mfc6490cw-bin-1.1.2_p2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7


### PR DESCRIPTION
Changing ownership from **Gentoo Foundation** to **Gentoo Authors** in ebuilds where the copyright end date is greater than 2018.

I believe that there's no need to update all copyright lines in a single swipe, but new/modified ebuilds with an end date greater than 2018 should assign the ownership to **Gentoo Authors** or as explained below.

[New Gentoo copyright policy explained (draft)](https://dev.gentoo.org/~mgorny/articles/new-gentoo-copyright-policy-explained.html#copyright-ownership)
```
On 2018-09-15 meeting, the Trustees have given the final stamp of approval
to the new Gentoo copyright policy outlined in GLEP 76.

With the simplified method, the copyright line will usually look like:

  # Copyright START[-END] Gentoo Authors

With the complete method, it would be:

  # Copyright START[-END] LARGEST-OWNER [and others]