### PR TITLE
add missing IUSE avahi in some metadata.xml files

### DIFF
--- a/net-print/brother-mfc7440n-bin/metadata.xml
+++ b/net-print/brother-mfc7440n-bin/metadata.xml
@@ -6,5 +6,6 @@
 <pkgmetadata>
 <longdescription>Printer driver for Brother MFC-7440N</longdescription>
 <use>
+  <flag name="avahi">Uses <pkg>net-dns/avahi</pkg> and <pkg>sys-auth/nss-mdns</pkg> to find printers with dynamically assigned IP addresses by name</flag>
 </use>
 </pkgmetadata>

--- a/net-print/brother-mfc9130cw-bin/metadata.xml
+++ b/net-print/brother-mfc9130cw-bin/metadata.xml
@@ -6,5 +6,6 @@
 <pkgmetadata>
 <longdescription>Printer driver for Brother MFC-9130CW</longdescription>
 <use>
+  <flag name="avahi">Uses <pkg>net-dns/avahi</pkg> and <pkg>sys-auth/nss-mdns</pkg> to find printers with dynamically assigned IP addresses by name</flag>
 </use>
 </pkgmetadata>

--- a/net-print/brother-mfc9320cw-bin/metadata.xml
+++ b/net-print/brother-mfc9320cw-bin/metadata.xml
@@ -6,5 +6,6 @@
 <pkgmetadata>
 <longdescription>Printer driver for Brother MFC-9320CW</longdescription>
 <use>
+  <flag name="avahi">Uses <pkg>net-dns/avahi</pkg> and <pkg>sys-auth/nss-mdns</pkg> to find printers with dynamically assigned IP addresses by name</flag>
 </use>
 </pkgmetadata>


### PR DESCRIPTION
Fixes IUSE.invalid: This ebuild has a variable in IUSE that is not in the use.desc or its metadata.xml file.