### PR TITLE
fix typo in net-print/brother-mfc7440n-bin ebuild file

### DIFF
--- a/net-print/brother-mfc7440n-bin/brother-mfc7440n-bin-3.1.0-r1.ebuild
+++ b/net-print/brother-mfc7440n-bin/brother-mfc7440n-bin-3.1.0-r1.ebuild
@@ -60,7 +60,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	einfo "If you don't use avahi with nss-mdns, you'll have to use a static IP address in your printer confiugration"
+	einfo "If you don't use avahi with nss-mdns, you'll have to use a static IP address in your printer configuration"
 	einfo "If you want to use a broadcasted name, add .local to it"
 	einfo "You can test if it's working with ping printername.local"
 }


### PR DESCRIPTION
brother-mfc7440n-bin-3.1.0-r1.ebuild: **confiugration** -> **configuration**