### PR TITLE
Basic uplift of dcp9022cdw to EAPI6

### DIFF
--- a/net-print/brother-dcp9022cdw-bin/brother-dcp9022cdw-bin-1.1.3.ebuild
+++ b/net-print/brother-dcp9022cdw-bin/brother-dcp9022cdw-bin-1.1.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 
 inherit eutils rpm linux-info
 
@@ -36,10 +36,6 @@ pkg_setup() {
 
 src_unpack() {
 	rpm_unpack ${A}
-}
-
-src_prepare() {
-	return
 }
 
 src_install() {


### PR DESCRIPTION
This is a very basic uplift of the dcp9022cdw ebuild from EAPI5 to
EAPI6. This is necessary to fix warnings arising from EAPI5 not
being supported any longer.

Besides stepping up the EAPI version, this change removes the
empty src_prepare phase and thereby utilizes the default
implementation of this phase.