### PR TITLE
Fix printer detection in cupswrapper script

### DIFF
--- a/net-print/brother-mfcl3770cdw-bin/brother-mfcl3770cdw-bin-1.0.2-r2.ebuild
+++ b/net-print/brother-mfcl3770cdw-bin/brother-mfcl3770cdw-bin-1.0.2-r2.ebuild
@@ -7,7 +7,7 @@ inherit rpm multilib
 PRINTER_MODEL=${PN#*-}
 PRINTER_MODEL=${PRINTER_MODEL%-*}
 
-DESCRIPTION="Brother printer drive for ${PRINTER_MODEL}"
+DESCRIPTION="Brother printer driver for ${PRINTER_MODEL}"
 HOMEPAGE="https://support.brother.com/g/b/downloadhowto.aspx?c=us&lang=en&prod=${PRINTER_MODEL}_us_eu_as"
 SRC_URI="
 	https://download.brother.com/welcome/dlf103949/${PRINTER_MODEL}pdrv-1.0.2-0.i386.rpm
@@ -30,6 +30,14 @@ S="${WORKDIR}"
 
 src_unpack() {
 	rpm_unpack ${A}
+}
+
+src_prepare() {
+	default
+	sed -i'' \
+		-e "s:my \$PRINTER=.*:my \$PRINTER='${PRINTER_MODEL}';:" \
+		-e 's:$PRINTER =~ .*::' \
+		"${S}"/opt/brother/Printers/${PRINTER_MODEL}/cupswrapper/brother_lpdwrapper_${PRINTER_MODEL}
 }
 
 src_install() {


### PR DESCRIPTION
Fix printer detection in cupswrapper/brother_lpdwrapper_mfcl3770. Without fix, the script fails to detect the printer name correctly and instead generates the name 'optbrotherPrintersmfcl3770cdw'. This is because the regular expressions the wrapper uses expects the symlink in /usr/libexec/cups/filter/brother_lpdwrapper_mfcl3770cdw to have an absolute target instead of a relative one.

Because there is likely to always be a scenario where the regular expressions in brother_lpdwrapper_mfcl3770 don't work, the solution here is to remove the regular expression logic and hardcode the printer name to mfcl3770cdw.